### PR TITLE
remove allow external

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -19,7 +19,7 @@ fi
 
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
-    pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+    pip install -r requirements.txt  --exists-action=w | indent
 fi
 
 # Clean up the installation environment .


### PR DESCRIPTION
The allow-all-external is removed in the newest version of pip.